### PR TITLE
refactor: Cập nhật method `get_profile_uid` và `post_feed`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 altgraph==0.17.4
 attrs==24.2.0
+beautifulsoup4==4.12.3
+bs4==0.0.2
 certifi==2024.7.4
 cffi==1.17.0
 charset-normalizer==3.3.2
@@ -22,6 +24,7 @@ requests==2.32.3
 selenium==4.23.1
 sniffio==1.3.1
 sortedcontainers==2.4.0
+soupsieve==2.5
 trio==0.26.2
 trio-websocket==0.11.1
 typing_extensions==4.12.2


### PR DESCRIPTION
- Thêm method `get_profile_uid` để trả về UID từ cookie.
- Thay đổi method `post_feed`:  - Thêm phần tag UID vào nội dung bài đăng.  
- Loại bỏ tham số `target_uid`.  - Nguồn tham khảo: https://www.thegioididong.com/game-app/cach-tag-ten-nguoi-la-tren-facebook-ma-khong-can-ket-ban-1362084